### PR TITLE
[FEAT] 물품 정보 페이지 구현 #35

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import ManageItem from './pages/ManageItem/ManageItem';
 import ManageItemDelete from './pages/ManageItem/ManageItemDelete';
 import ManageItemAdd from './pages/ManageItem/ManageItemAdd';
 import ManageItemInfo from './pages/ManageItem/ManageItemInfo';
+import ManageItemEdit from './pages/ManageItem/ManageItemEdit';
 
 const App = () => {
     return (
@@ -38,7 +39,8 @@ const App = () => {
                 <Route path="/manage/item" element={<ManageItem/>}/>
                 <Route path="/manage/item/delete" element={<ManageItemDelete/>}/>
                 <Route path="/manage/item/add" element={<ManageItemAdd/>}/>
-                <Route path="/manage/item/Info" element={<ManageItemInfo/>}/>
+                <Route path="/manage/item/info" element={<ManageItemInfo/>}/>
+                <Route path="/manage/item/edit" element={<ManageItemEdit/>}/>
             </Routes>
         </Router>
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import RentalItemComplete from './pages/RentalItem/RentalItemComplete';
 import ManageItem from './pages/ManageItem/ManageItem';
 import ManageItemDelete from './pages/ManageItem/ManageItemDelete';
 import ManageItemAdd from './pages/ManageItem/ManageItemAdd';
+import ManageItemInfo from './pages/ManageItem/ManageItemInfo';
 
 const App = () => {
     return (
@@ -37,6 +38,7 @@ const App = () => {
                 <Route path="/manage/item" element={<ManageItem/>}/>
                 <Route path="/manage/item/delete" element={<ManageItemDelete/>}/>
                 <Route path="/manage/item/add" element={<ManageItemAdd/>}/>
+                <Route path="/manage/item/Info" element={<ManageItemInfo/>}/>
             </Routes>
         </Router>
     );

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -2,7 +2,7 @@ import style from './Navbar.module.css';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 
-const Navbar = ({ title, onBackClick, home=false, shadow=false }) => {
+const Navbar = ({ title, onBackClick, home=false, shadow=false, isStudentCouncil=false }) => {
     const navigate = useNavigate();
     const handleBackClick = (e) => {
         e.preventDefault();
@@ -18,7 +18,7 @@ const Navbar = ({ title, onBackClick, home=false, shadow=false }) => {
                     <ion-icon size="large" name="chevron-back-outline" style={{ cursor: 'pointer' }}></ion-icon>
                 </div>
                 <h2>{title}</h2>
-                <div className={style.home} onClick={() => navigate('/main')}>
+                <div className={style.home} onClick={() => {isStudentCouncil?navigate('/admin/main'):navigate('/main')}}>
                     <ion-icon name="home-outline" style={{ cursor: 'pointer' }}></ion-icon>
                 </div>
             </nav>
@@ -41,6 +41,7 @@ Navbar.propTypes = {
     onClick: PropTypes.func,
     home:PropTypes.bool,
     shadow:PropTypes.bool,
+    isStudentCouncil:PropTypes.bool,
 };
 
 export default Navbar;

--- a/src/components/page/ItemAddEdit.jsx
+++ b/src/components/page/ItemAddEdit.jsx
@@ -1,0 +1,108 @@
+import style from './ItemAddEdit.module.css';
+import Navbar from '../Navbar/Navbar';
+import SignupInput from '../Input/SignupInput';
+import Button from '../Button/Button';
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import ConfirmDialog from '../Dialog/ConfirmDialog';
+
+const ItemAddEdit = ({title, buttonText, data}) => {
+    const [itemName, setItemName] = useState(data?.itemName||'');
+    const [itemAmount, setItemAmount] = useState(data?.itemAmount||'');
+    const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const navigate = useNavigate();
+
+    const checkInputs = useCallback(() => {
+        if (itemName && itemAmount) {
+            setIsButtonDisabled(false);
+        } else {
+            setIsButtonDisabled(true);
+        }
+    }, [itemName, itemAmount]);
+
+    const handleItemName = (e) => {
+        setItemName(e.target.value)
+    };
+
+    const handleItemAmount = (e) => {
+        setItemAmount(e.target.value)
+    };
+
+    const handleDialogClose = () => {
+        setDialogOpen(false);
+    };
+
+    const handleConfirmEdit = () => {
+        console.log("Item edited!");
+        setDialogOpen(false);
+        navigate('/manage/item/info')
+    };
+
+    const handleItem= (e) => {
+        e.preventDefault();
+
+        if (itemName && itemAmount) {
+            if(data) {
+                console.log("수정 처리")
+                setDialogOpen(true)
+            } else {
+                console.log("추가 처리")
+                navigate('/manage/item')
+            }
+        }
+    };
+
+    useEffect(() => {
+        checkInputs();
+    }, [itemName, itemAmount, data, checkInputs]);
+
+
+    return (
+        <div className={`${style.container} pageContainer`}>
+            <Navbar title={title} shadow={true} onBackClick={() => window.history.back()}/>
+            <div className={`${style.itemImage}`}>
+                <ion-icon name="camera"></ion-icon>
+            </div>
+            <SignupInput
+                type="text"
+                id="itemName"
+                label="물품 이름"
+                placeholder="물품 이름 입력"
+                value={itemName}
+                onChange={handleItemName}
+                />
+            <SignupInput
+                type="number"
+                id="itemAmount"
+                label="수량"
+                placeholder="수량 입력"
+                value={itemAmount}
+                onChange={handleItemAmount}
+                />
+            <Button
+                text={buttonText}
+                onClick={handleItem}                    
+                className={`fixWidth ${style.itemAddButton} ${isButtonDisabled ? "disabled" : ''}`} disabled={isButtonDisabled} 
+            />
+            <ConfirmDialog
+                title="변경 사항 저장"
+                description="변경 사항을 정말 저장하시겠습니까? 저장 후에는 되돌릴 수 없습니다."
+                closeText="취소"
+                confirmText="저장"
+                open={dialogOpen}
+                onClose={handleDialogClose}
+                onConfirm={handleConfirmEdit}
+            />
+        </div>
+    )
+};
+
+ItemAddEdit.propTypes = {
+    title: PropTypes.string.isRequired,
+    buttonText: PropTypes.number.isRequired,
+    data: PropTypes.array,
+};
+
+export default ItemAddEdit;

--- a/src/components/page/ItemAddEdit.module.css
+++ b/src/components/page/ItemAddEdit.module.css
@@ -1,0 +1,30 @@
+.container{
+    padding-top: 80px;
+}
+
+.itemImage {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background-color: #ececec;
+    border-radius: 10%;
+    margin-bottom: 30px;
+}
+.itemImage ion-icon{
+    font-size: 28px;
+    position: absolute;
+    bottom: -5px;;
+    right: -8px;
+    z-index: 2;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.itemAddButton {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+}

--- a/src/components/page/MainPage.jsx
+++ b/src/components/page/MainPage.jsx
@@ -64,8 +64,8 @@ const MainPage = ({name, isStudentCouncil}) => {
                     />
             </div>
             <MainCard
-                title={isStudentCouncil?"상세 대여 정보":'대여 정보'}
-                description={isStudentCouncil?"상세 대여 정보를 확인할 수 있어요":'대여 정보를 확인할 수 있어요'}
+                title={isStudentCouncil?"학생 유저 승인":'대여 정보'}
+                description={isStudentCouncil?"학생 유저의 회원가입을 승인할 수 있어요":'대여 정보를 확인할 수 있어요'}
                 backgroundColor='#b4bfb6'
                 titleColor='white'
                 descriptionColor='white'

--- a/src/pages/ManageItem/ManageItem.jsx
+++ b/src/pages/ManageItem/ManageItem.jsx
@@ -19,7 +19,7 @@ const ManageItem = () => {
 
     return (
         <div className={`pageContainer ${style.container}`}>
-            <Navbar title="관리 물품 선택" onBackClick={() => navigate('admin/main')} shadow={true}/>
+            <Navbar title="관리 물품 선택" onBackClick={() => window.history.back()} shadow={true}/>
             <div className={style.studentCouncilInfoBox}>
                 <p className={style.name}>총학생회 HEYDAY</p>
                 <p className={style.address}>제1학생회관</p>

--- a/src/pages/ManageItem/ManageItem.jsx
+++ b/src/pages/ManageItem/ManageItem.jsx
@@ -29,7 +29,7 @@ const ManageItem = () => {
                     <ItemCard 
                         key={item.id}
                         item={item.name}
-                        onClick = {() => {}}/>
+                        onClick = {() => navigate('/manage/item/info')}/>
                 )
             })}
             <ItemFab 

--- a/src/pages/ManageItem/ManageItemAdd.jsx
+++ b/src/pages/ManageItem/ManageItemAdd.jsx
@@ -1,73 +1,10 @@
-import style from './ManageItemAdd.module.css';
-import Navbar from '../../components/Navbar/Navbar';
-import SignupInput from '../../components/Input/SignupInput';
-import Button from '../../components/Button/Button';
-import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import ItemAddEdit from "../../components/page/ItemAddEdit";
 
 const ManageItemAdd = () => {
-    const [itemName, setItemName] = useState('');
-    const [itemAmount, setItemAmount] = useState('');
-    const [isButtonDisabled, setIsButtonDisabled] = useState(true);
-    const navigate = useNavigate();
-
-    const checkInputs = useCallback(() => {
-        if (itemName && itemAmount) {
-            setIsButtonDisabled(false);
-        } else {
-            setIsButtonDisabled(true);
-        }
-    }, [itemName, itemAmount]);
-
-    const handleItemName = (e) => {
-        setItemName(e.target.value)
-    };
-
-    const handleItemAmount = (e) => {
-        setItemAmount(e.target.value)
-    };
-
-    const handleItemAdd = (e) => {
-        e.preventDefault();
-
-        if (itemName && itemAmount) {
-            navigate('/manage/item')
-        }
-    };
-
-    useEffect(() => {
-        checkInputs();
-    }, [itemName, itemAmount, checkInputs]);
-
-
     return (
-        <div className={`${style.container} pageContainer`}>
-            <Navbar title='물품 추가' shadow={true} onBackClick={() => window.history.back()}/>
-            <div className={`${style.itemImage}`}>
-                <ion-icon name="camera"></ion-icon>
-            </div>
-                <SignupInput
-                    type="text"
-                    id="itemName"
-                    label="물품 이름"
-                    placeholder="물품 이름 입력"
-                    value={itemName}
-                    onChange={handleItemName}
-                    />
-                <SignupInput
-                    type="number"
-                    id="itemAmount"
-                    label="수량"
-                    placeholder="수량 입력"
-                    value={itemAmount}
-                    onChange={handleItemAmount}
-                    />
-                <Button
-                    text="다음"
-                    onClick={handleItemAdd}                    
-                    className={`fixWidth ${style.itemAddButton} ${isButtonDisabled ? "disabled" : ''}`} disabled={isButtonDisabled} 
-                />
-        </div>
+        <ItemAddEdit 
+            title="물품 추가" 
+            buttonText="추가하기" />
     )
 };
 

--- a/src/pages/ManageItem/ManageItemEdit.jsx
+++ b/src/pages/ManageItem/ManageItemEdit.jsx
@@ -1,0 +1,17 @@
+import ItemAddEdit from "../../components/page/ItemAddEdit";
+
+const ManageItemEdit = () => {
+    const tempItemInfo = 
+        {
+            itemName: "우산(소)",
+            itemAmount: 15
+        }
+    return (
+        <ItemAddEdit 
+            title="물품 수정" 
+            buttonText="수정하기" 
+            data={tempItemInfo}/>
+    )
+};
+
+export default ManageItemEdit;

--- a/src/pages/ManageItem/ManageItemInfo.jsx
+++ b/src/pages/ManageItem/ManageItemInfo.jsx
@@ -7,7 +7,7 @@ const ManageItemInfo = () => {
     const navigate = useNavigate();
     return (
         <div className={`${style.container} pageContainer`}>
-            <Navbar title="물품 정보 보기" shadow={true} home="true" onBackClick={() => window.history.back()}/>
+            <Navbar title="물품 정보 보기" shadow={true} home="true"  isStudentCouncil={true} onBackClick={() => window.history.back()}/>
             <div className={style.itemBox}>
                 <div className={`${style.itemImage} circle`}>
 
@@ -38,7 +38,7 @@ const ManageItemInfo = () => {
             </div>
             <Button
                     text="수정하기"
-                    onClick={()=>{}}                    
+                    onClick={()=>navigate('/manage/item/edit')}                    
                     className={`fixWidth ${style.itemEditButton}`}
                 />
         </div>

--- a/src/pages/ManageItem/ManageItemInfo.jsx
+++ b/src/pages/ManageItem/ManageItemInfo.jsx
@@ -1,0 +1,48 @@
+import style from './ManageItemInfo.module.css';
+import Navbar from '../../components/Navbar/Navbar';
+import Button from '../../components/Button/Button';
+import { useNavigate } from 'react-router-dom';
+
+const ManageItemInfo = () => {
+    const navigate = useNavigate();
+    return (
+        <div className={`${style.container} pageContainer`}>
+            <Navbar title="물품 정보 보기" shadow={true} home="true" onBackClick={() => window.history.back()}/>
+            <div className={style.itemBox}>
+                <div className={`${style.itemImage} circle`}>
+
+                </div>
+                <div className={style.itemNameBox}>
+                    <p className={style.name}>우산(대)</p>
+                    <p className={style.address}>제1학생회관</p>
+                </div>
+            </div>
+            <hr/>
+            <div className={style.itemInfoBox}>
+                <div className={style.textBox}>
+                    <p>재고</p>
+                    <p className={style.amount}>15</p>
+                </div>
+                <div className={style.textBox}>
+                    <p>대여중</p>
+                    <p className={style.amount}>3</p>
+                </div>
+                <div className={style.textBox}>
+                    <p>대여 예약</p>
+                    <p className={style.amount}>1</p>
+                </div>
+                <div className={style.textBox}>
+                    <p>총량</p>
+                    <p className={style.amount}>19</p>
+                </div>
+            </div>
+            <Button
+                    text="수정하기"
+                    onClick={()=>{}}                    
+                    className={`fixWidth ${style.itemEditButton}`}
+                />
+        </div>
+    )
+};
+
+export default ManageItemInfo;

--- a/src/pages/ManageItem/ManageItemInfo.module.css
+++ b/src/pages/ManageItem/ManageItemInfo.module.css
@@ -1,0 +1,65 @@
+.container {
+    padding-top: 60px;
+}
+
+.container hr {
+    width: 100%;
+    margin-bottom: 0;
+    margin-top: 0;
+    border: 4px solid #ccc;
+}
+
+.itemImage {
+    width: 100px;
+    height: 100px;
+    background-color: var(--card-background-gray);
+    margin-right: 20px;
+}
+
+.itemBox {
+    width: 100%;
+    display: flex;
+    margin: 20px 0;
+    text-align: start;
+}
+
+.name {
+    font-size: 20px;
+    font-weight: 800;
+    margin-bottom: 5px;
+}
+
+.address {
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--sub-text-gray);
+    margin-top: 5px;
+}
+
+.itemInfoBox {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+}
+
+.textBox {
+    flex: 1;
+    margin-top: 20px;
+}
+
+.textBox p {
+    letter-spacing: -0.05em;
+    margin: 0;
+}
+
+.amount {
+    font-weight: 600;
+    font-size: 22px;
+}
+
+.itemEditButton {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35

## 📝작업 내용

> [Feat: 물품 정보 보기 페이지 구현]
> [Fix: 관리자 메인 표기 오류 수정]
>[Feat : 물품 수정, 삭제 페이지 컴포넌트로 관리]
> [Feat: 물품 수정 페이지 추가]
>[Refact : 물품 추가수정 페이지 컴포넌트화에 따른 리팩토링]
> [Fix: 관리자 페이지의 메인 버튼이 유저용 메인으로 가는 버그 수정]

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
