### PR TITLE
Fix: Main화면 유저/관리자에 따른 화면 처리

### DIFF
--- a/src/components/page/MainPage.jsx
+++ b/src/components/page/MainPage.jsx
@@ -1,12 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import MainCard from '../Card/MainCard';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import apiClient from '../../services/apiClient';
 import style from './MainPage.module.css';
-import { USER_ID } from '../../constants/userId';
 
-const MainPage = () => {
+const MainPage = ({userId}) => {
   const navigate = useNavigate();
 
   const [userName, setUserName] = useState('');
@@ -23,16 +22,15 @@ const MainPage = () => {
     const fetchUserData = async () => {
       try {
         // 사용자 정보 API 호출
-        const response = await apiClient.get(`api/v1/users/${USER_ID}`);
-        const { name, studentCouncilId } = response.data;
+        const response = await apiClient.get(`api/v1/users/${userId}`);
+        const { name, isStudentCouncil } = response.data;
 
         setUserName(name);
-        const isCouncil = studentCouncilId !== null;
-        setIsStudentCouncil(isCouncil);
+        setIsStudentCouncil(isStudentCouncil);
 
         // 학생회 여부에 따라 대기중/처리중 요청 카운트
-        if (isCouncil) {
-          await fetchRentalRequests(studentCouncilId);
+        if (isStudentCouncil) {
+          await fetchRentalRequests(isStudentCouncil);
         }
       } catch (error) {
         console.error("Failed to fetch user data:", error);
@@ -164,7 +162,7 @@ const MainPage = () => {
 };
 
 MainPage.propTypes = {
-  userId: PropTypes.string,
+  userId: PropTypes.number.isRequired,
 };
 
 export default MainPage;

--- a/src/constants/userId.js
+++ b/src/constants/userId.js
@@ -1,1 +1,4 @@
-export const USER_ID = 1;
+export const USER_ID = {
+    USER : 1,
+    ADMIN: 2
+};

--- a/src/pages/Main/Main.jsx
+++ b/src/pages/Main/Main.jsx
@@ -1,7 +1,8 @@
 import MainPage from '../../components/page/MainPage';
+import { USER_ID } from '../../constants/userId';
 const Main = () => {
     return (
-        <MainPage name='이현호' isStudentCouncil={false}/>
+        <MainPage userId={USER_ID.USER}/>
     );
 };
 

--- a/src/pages/Main/MainAdmin.jsx
+++ b/src/pages/Main/MainAdmin.jsx
@@ -1,7 +1,8 @@
 import MainPage from '../../components/page/MainPage';
+import { USER_ID } from '../../constants/userId';
 const MainAdmin = () => {
     return (
-        <MainPage name='이현호' isStudentCouncil={true}/>
+        <MainPage userId={USER_ID.ADMIN}/>
     );
 };
 

--- a/src/pages/Main/MyPage.jsx
+++ b/src/pages/Main/MyPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import style from "./MyPage.module.css";
 import Navbar from "../../components/Navbar/Navbar";
 import apiClient from "../../services/apiClient";


### PR DESCRIPTION
## #️⃣연관된 이슈

> #58

## 📝작업 내용

> 전역상수에서 유저/관리자 동시에 관리하도록 변경
> 백에서 user_id에 isStudentCouncil값을 불러옴에 따라 Main 화면 분기처리 로직 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
